### PR TITLE
Allow comment in the same line as values

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,14 @@
+# PRJ:=cfgio
+PRJ:= 
 FC=ifort
 FFLAG=-O2
 INC=../include
-LIB=../lib
+
+# Added installation Path
+# prefix:=$(HOME)/.local
+prefix:=..
+INSTALL_LIB= $(prefix)/lib
+INSTALL_INCLUDE= $(prefix)/include/$(PRJ)
 
 TARGET=libcfgio.a
 OBJECTS= string_conv_mod.o cfgio_mod.o
@@ -17,9 +24,10 @@ $(TARGET): $(OBJECTS)
 	$(FC) $(FFLAG) -c $< -I$(INC)
 
 install: $(TARGET)
-	mkdir -p $(INC) $(LIB)
-	cp *.mod $(INC)
-	cp $(TARGET) $(LIB)
+	mkdir -p $(INSTALL_INCLUDE) $(INSTALL_LIB)
+	cp *.mod $(INSTALL_INCLUDE)
+	cp $(TARGET) $(INSTALL_LIB)
 
 clean:
 	rm *.mod *.o *.a
+	

--- a/src/cfgio_mod.f90
+++ b/src/cfgio_mod.f90
@@ -3,7 +3,7 @@
 ! Date    :
 
 module cfgio_mod
-    use string_conv_mod, only: from_string,tolist,unquote,list_size,list_size_cmplx,list_size_str
+    use string_conv_mod, only: from_string,tolist,strip,unquote,list_size,list_size_cmplx,list_size_str
     implicit none
     private
     public:: cfg_t, parse_cfg !! main
@@ -415,8 +415,23 @@ contains
     logical found
     call find_sect_key(cfg,section,key,isect,ikey)
     val=cfg%s(isect)%p(ikey)%val
-    read (val, *) val
+    val = unquote(strip(remove_comment(val)))
     end function
+
+    function remove_comment(istr) result(ostr)
+      implicit none
+      character(len=*):: istr !<
+      ! character(len=len(istr)):: ostr !<
+      character(len=:), allocatable :: ostr !<
+      character(len=*), parameter :: com = "#;"
+      integer :: id
+      id = scan(istr, com)
+      if (id /= 0) then
+        ostr = istr(1:id - 1)
+      else
+        ostr = istr
+      end if
+    end function remove_comment
 
     function interpolate_str(cfg,section,str) result(val)
     ! interpolation ${section:key}

--- a/src/cfgio_mod.f90
+++ b/src/cfgio_mod.f90
@@ -415,7 +415,7 @@ contains
     logical found
     call find_sect_key(cfg,section,key,isect,ikey)
     val=cfg%s(isect)%p(ikey)%val
-    val=unquote(val)
+    read (val, *) val
     end function
 
     function interpolate_str(cfg,section,str) result(val)

--- a/src/string_conv_mod.f90
+++ b/src/string_conv_mod.f90
@@ -8,6 +8,7 @@ module string_conv_mod
     integer,parameter:: MXNSTR=256
     integer, parameter:: sp=kind(0.0)
     integer, parameter:: dp=kind(0.d0)
+    character(*), parameter :: blanks = ' '//achar(9) ! blanks and tabs
 
     ! subroutines
     interface from_string
@@ -50,10 +51,35 @@ module string_conv_mod
     public:: from_string,to_string
     public:: tostr,tolist
     public:: list_size,list_size_cmplx,list_size_str
-    public:: quote,unquote
+    public:: quote,unquote,strip
     public:: s2i,s2f,s2d,s2c,s2z,s2b
 
 contains
+
+    !> This function returns a copy of the string with leading chars removed
+    !!
+    !! If chars is not present all blank: spaces (achar(32)) and tabs (achar(9))
+    !! are removed.
+    !! @note that when used with no `chars` argument differs from intrinsic `trim`
+    !! in that it will also strip "tab" characters
+    pure function strip(S, chars) result(Sout)
+      implicit none
+      character(len=*), intent(IN) :: S               !< Original string
+      character(len=*), optional, intent(IN) :: chars !< chars to remove from S
+      character(len=:), allocatable :: Sout !< String with chars removed
+      integer :: ni, nf
+      character(len=:), allocatable :: ch_
+  
+      ch_ = blanks; IF (present(chars)) ch_ = chars
+  
+      ni = verify(S, ch_)
+      if (ni == 0) ni = 1
+  
+      nf = verify(S, ch_, back=.True.)
+      if (nf == 0) nf = len(S)
+  
+      Sout = S(ni:nf)
+    end function strip
 
     pure function quote(str) result(v)
     character(len=*),intent(in):: str


### PR DESCRIPTION
In its present form the library allows comments in the same line that are defined the pairs 'key=values'
but it does not work for interpolation. The very small change proposed would allow that.

The proposed change will fix the behavior, for the fail in the following (modified) example:

```
[DEFAULTS]
path = ../include        # Default Path to files
use_abs = True

[Section 1]
nmax = 30
# comment 1
vmin = 1.0
freqs = 5.0, 10.0, 30.0, 50.0
amps = 0.0, 1.0, 1.0, 0.0
path = ../text          # Path to files

[Section 2]
use_abs = no
; comment 2
my file = ${Section 1:path}/file.txt
```